### PR TITLE
Handle -r flag in requirements.txt

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,5 +61,7 @@ Real life example::
   max-line-length = 100
   known-modules = my-lib:[mylib.drm,mylib.encryption]
 
-If you use the ``-r`` flag in your ``requirements.txt`` file, add the ``--requirements-max-depth``
-option to flake8 (for example, ``--requirements-max-depth=1`` to allow one level of recursion).
+If you use the ``-r`` flag in your ``requirements.txt`` file with more than one level of recursion
+(in other words, one file includes another, the included file includes yet another, and so on),
+add the ``--requirements-max-depth`` option to flake8 (for example, ``--requirements-max-depth=3``
+to allow three levels of recursion).

--- a/README.rst
+++ b/README.rst
@@ -60,3 +60,6 @@ Real life example::
   [flake8]
   max-line-length = 100
   known-modules = my-lib:[mylib.drm,mylib.encryption]
+
+If you use the ``-r`` flag in your ``requirements.txt`` file, add the ``--requirements-max-depth``
+option to flake8 (for example, ``--requirements-max-depth=1`` to allow one level of recursion).

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -105,6 +105,7 @@ class Flake8CheckerTestCase(unittest.TestCase):
     def test_custom_mapping_parser(self):
         class Flake8Options:
             known_modules = ":[pydrmcodec],mylib:[mylib.drm,mylib.ex]"
+            requirements_max_depth = 0
         Flake8Checker.parse_options(Flake8Options)
         self.assertEqual(
             Flake8Checker.known_modules,
@@ -114,6 +115,7 @@ class Flake8CheckerTestCase(unittest.TestCase):
     def test_custom_mapping(self):
         class Flake8Options:
             known_modules = "flake8-requires:[flake8req]"
+            requirements_max_depth = 0
         Flake8Checker.parse_options(Flake8Options)
         errors = check("from flake8req import mymodule")
         self.assertEqual(len(errors), 0)

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -1,0 +1,136 @@
+from pkg_resources import parse_requirements
+from unittest import TestCase
+from unittest.mock import mock_open, patch
+
+from flake8_requirements.checker import Flake8Checker
+
+
+class RequirementsTestCase(TestCase):
+
+    def test_resolve_requirement_with_blank(self):
+        self.assertEqual(Flake8Checker.resolve_requirement(""), [])
+
+    def test_resolve_requirement_with_comment(self):
+        self.assertEqual(
+            Flake8Checker.resolve_requirement("#-r requirements.txt"),
+            [],
+        )
+
+    def test_resolve_requirement_with_simple(self):
+        self.assertEqual(
+            Flake8Checker.resolve_requirement("foo >= 1.0.0"),
+            ["foo >= 1.0.0"],
+        )
+
+    def test_resolve_requirement_with_file_beyond_max_depth(self):
+        with self.assertRaises(RecursionError):
+            Flake8Checker.resolve_requirement("-r requirements.txt")
+
+    def test_resolve_requirement_with_file_empty(self):
+        with patch("builtins.open", mock_open()) as m:
+            self.assertEqual(
+                Flake8Checker.resolve_requirement("-r requirements.txt", 1),
+                [],
+            )
+            m.assert_called_once_with("requirements.txt")
+
+    def test_resolve_requirement_with_file_content(self):
+        content = "foo >= 1.0.0\nbar <= 1.0.0\n"
+        with patch("builtins.open", mock_open(read_data=content)):
+            self.assertEqual(
+                Flake8Checker.resolve_requirement("-r requirements.txt", 1),
+                ["foo >= 1.0.0\n", "bar <= 1.0.0\n"],
+            )
+
+    def test_resolve_requirement_with_file_recursion_beyond_max_depth(self):
+        content = "-r requirements.txt\n"
+        with patch("builtins.open", mock_open(read_data=content)):
+            with self.assertRaises(RecursionError):
+                Flake8Checker.resolve_requirement("-r requirements.txt", 1),
+
+    def test_resolve_requirement_with_file_recursion(self):
+        content = "foo >= 1.0.0\n-r inner.txt\nbar <= 1.0.0\n"
+        inner_content = "# inner\nbaz\n\nqux\n"
+
+        with patch("builtins.open", mock_open()) as m:
+            m.side_effect = (
+                mock_open(read_data=content).return_value,
+                mock_open(read_data=inner_content).return_value,
+            )
+
+            self.assertEqual(
+                Flake8Checker.resolve_requirement("-r requirements.txt", 2),
+                ["foo >= 1.0.0\n", "baz\n", "qux\n", "bar <= 1.0.0\n"],
+            )
+
+    def test_init_with_no_requirements(self):
+        with patch("os.path.exists", return_value=False) as exists:
+            with patch("builtins.open", mock_open()) as m:
+                checker = Flake8Checker(None, None)
+                self.assertEqual(checker.requirements, ())
+                m.assert_called_once_with("setup.py")
+            exists.assert_called_once_with("requirements.txt")
+
+    def test_init_with_simple_requirements(self):
+        requirements_content = "foo >= 1.0.0\nbar <= 1.0.0\n"
+        setup_content = ""
+
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open()) as m:
+                m.side_effect = (
+                    mock_open(read_data=requirements_content).return_value,
+                    mock_open(read_data=setup_content).return_value,
+                )
+
+                checker = Flake8Checker(None, None)
+                self.assertEqual(
+                    sorted(checker.requirements, key=lambda x: x.project_name),
+                    sorted(parse_requirements([
+                        "foo >= 1.0.0",
+                        "bar <= 1.0.0",
+                    ]), key=lambda x: x.project_name),
+                )
+
+    def test_init_with_recursive_requirements_beyond_max_depth(self):
+        requirements_content = "foo >= 1.0.0\n-r inner.txt\nbar <= 1.0.0\n"
+        inner_content = "# inner\nbaz\n\nqux\n"
+        setup_content = ""
+
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open()) as m:
+                m.side_effect = (
+                    mock_open(read_data=requirements_content).return_value,
+                    mock_open(read_data=inner_content).return_value,
+                    mock_open(read_data=setup_content).return_value,
+                )
+
+                with self.assertRaises(RecursionError):
+                    Flake8Checker(None, None)
+
+    def test_init_with_recursive_requirements(self):
+        requirements_content = "foo >= 1.0.0\n-r inner.txt\nbar <= 1.0.0\n"
+        inner_content = "# inner\nbaz\n\nqux\n"
+        setup_content = ""
+
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open()) as m:
+                m.side_effect = (
+                    mock_open(read_data=requirements_content).return_value,
+                    mock_open(read_data=inner_content).return_value,
+                    mock_open(read_data=setup_content).return_value,
+                )
+
+                try:
+                    Flake8Checker.requirements_max_depth = 1
+                    checker = Flake8Checker(None, None)
+                finally:
+                    Flake8Checker.requirements_max_depth = 0
+                self.assertEqual(
+                    sorted(checker.requirements, key=lambda x: x.project_name),
+                    sorted(parse_requirements([
+                        "foo >= 1.0.0",
+                        "baz",
+                        "qux",
+                        "bar <= 1.0.0",
+                    ]), key=lambda x: x.project_name),
+                )


### PR DESCRIPTION
Resolve recursive requirements (ie `-r` flag) in requirements.txt when
`--requirements-max-depth` flag is specified. Behavior remains the same
as before if flag not specified.