### PR TITLE
Ignore some options in requirements.txt

### DIFF
--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -322,8 +322,17 @@ class Flake8Checker(object):
 
         if requirement.startswith("#") or not requirement:
             return []
-
-        if requirement.startswith("-r "):
+        
+        if requirement.startswith("-i ") or requirement.startswith("--index-url "):
+            return []
+        
+        if requirement.startswith("--extra-index-url "):
+            return []
+        
+        if requirement.startswith("--no-index"):
+            return []
+        
+        if requirement.startswith("-r ") or requirement.startswith("--requirement "):
             # Error out if we need to recurse deeper than allowed.
             if max_depth <= 0:
                 msg = "Cannot resolve {}: beyond max depth"


### PR DESCRIPTION
Pip documentation has finally been updated for requirements.txt format specification.  Some of the options don't appear to be relevant to what flake8-requirements is doing.  Other options could also potentially be ignored, or may require special handling to implement support for them in flake8-requirements.

https://pip.pypa.io/en/stable/reference/pip_install/#requirements-file-format
https://pip.pypa.io/en/stable/news/#improved-documentation
https://github.com/pypa/pip/issues/7385

Partially fixes #9