### PR TITLE
Correctly ignore comment lines

### DIFF
--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -73,6 +73,8 @@ def joinlines(lines):
     joined_line = ""
     for line in map(lambda x: x.strip(), lines):
         if not line or line.startswith("#"):
+            yield joined_line
+            joined_line = ""
             continue
         if line.endswith("\\"):
             joined_line += line[:-1]


### PR DESCRIPTION
Correctly ignore comment lines following a line continuation character at the end of the previous line.

Fixes #14