### PR TITLE
Add PyGObject to known modules.

### DIFF
--- a/src/flake8_requirements/modules.py
+++ b/src/flake8_requirements/modules.py
@@ -528,6 +528,7 @@ KNOWN_3RD_PARTIES = {
     "pillow": ["PIL"],
     "protobuf": ["google.protobuf"],
     "py_lru_cache": ["lru"],
+    "pygobject": ["gi", "pygtkcompat"],
     "pyhamcrest": ["hamcrest"],
     "pyicu": ["icu"],
     "pyjwt": ["jwt"],


### PR DESCRIPTION
Not sure if this should be all lowercase, or match PyPI which lists it as "PyGObject".
I'm assuming the code will match it case-insensitively. Though, maybe it's a better idea to show the PyPI case in the error output?