### PR TITLE
Requirements folders

### DIFF
--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -357,7 +357,7 @@ class Flake8Checker(object):
             root_dir = os.path.abspath(os.path.join(root_dir, ".."))
 
     @classmethod
-    def resolve_requirement(cls, requirement, max_depth=0, path=None):
+    def resolve_requirement(cls, requirement, max_depth=0, parent_path=None):
         """Resolves flags like -r in an individual requirement line."""
 
         option = None
@@ -377,13 +377,15 @@ class Flake8Checker(object):
                 raise RuntimeError(msg.format(requirement))
             resolved = []
             # Error out if requirements file cannot be opened.
-            if not path:
-                path = cls.root_dir
-            with open(os.path.join(path, requirement)) as f:
+            if not parent_path:
+                parent_path = cls.root_dir
+            with open(os.path.join(parent_path, requirement)) as f:
                 for line in joinlines(f.readlines()):
                     resolved.extend(cls.resolve_requirement(
-                        line, max_depth - 1, os.path.join(cls.root_dir,
-                                                          os.path.dirname(requirement))))
+                        line,
+                        max_depth - 1,
+                        os.path.join(cls.root_dir,
+                                     os.path.dirname(requirement))))
             return resolved
 
         if option:

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -357,7 +357,7 @@ class Flake8Checker(object):
             root_dir = os.path.abspath(os.path.join(root_dir, ".."))
 
     @classmethod
-    def resolve_requirement(cls, requirement, max_depth=0):
+    def resolve_requirement(cls, requirement, max_depth=0, path=None):
         """Resolves flags like -r in an individual requirement line."""
 
         option = None
@@ -377,10 +377,13 @@ class Flake8Checker(object):
                 raise RuntimeError(msg.format(requirement))
             resolved = []
             # Error out if requirements file cannot be opened.
-            with open(os.path.join(cls.root_dir, requirement)) as f:
+            if not path:
+                path = cls.root_dir
+            with open(os.path.join(path, requirement)) as f:
                 for line in joinlines(f.readlines()):
                     resolved.extend(cls.resolve_requirement(
-                        line, max_depth - 1))
+                        line, max_depth - 1, os.path.join(cls.root_dir,
+                                                          os.path.dirname(requirement))))
             return resolved
 
         if option:


### PR DESCRIPTION
Fix for #28.

I avoided changing the working directory as this may cause unforeseen issues elsewhere or in the future. So instead I pass the path of the current requirements file to give context to recursive calls to resolve_requirement.

I've added a test that passes, as do existing tests. I have also run against some of my own code with different requirement.txt structures and all are working.

If I've missed any use cases I'm happy to amend based on a pseudo test.