### PR TITLE
Allow override of known 3rd parties

### DIFF
--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -656,13 +656,14 @@ class Flake8Checker(object):
         mods_3rd_party = ModuleSet()
         # Get 3rd party module names based on requirements.
         for requirement in self.get_mods_3rd_party_requirements():
-            modules = [project2module(requirement.project_name)]
-            if modules[0] in self.known_3rd_parties:
-                modules = self.known_3rd_parties[modules[0]]
-            elif modules[0] in self.known_host_3rd_parties:
-                modules = self.known_host_3rd_parties[modules[0]]
-            elif modules[0] in self.known_modules:
-                modules = self.known_modules[modules[0]]
+            modules = (
+                self.known_3rd_parties.get(modules[0], []) +
+                self.known_host_3rd_parties.get(modules[0], []) +
+                self.known_modules.get(modules[0], [])
+            )
+            if not modules:
+                modules = [project2module(requirement.project_name)]
+
             for module in modules:
                 mods_3rd_party.add(modsplit(module), requirement)
         return mods_3rd_party

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -656,13 +656,20 @@ class Flake8Checker(object):
         mods_3rd_party = ModuleSet()
         # Get 3rd party module names based on requirements.
         for requirement in self.get_mods_3rd_party_requirements():
+            mod = project2module(requirement.project_name)
             modules = (
-                self.known_3rd_parties.get(modules[0], []) +
-                self.known_host_3rd_parties.get(modules[0], []) +
-                self.known_modules.get(modules[0], [])
+                self.known_3rd_parties.get(mod, []) +
+                self.known_host_3rd_parties.get(mod, []) +
+                self.known_modules.get(mod, [])
             )
             if not modules:
-                modules = [project2module(requirement.project_name)]
+                unknown = (
+                    mod not in self.known_3rd_parties and
+                    mod not in self.known_host_3rd_parties and
+                    mod not in self.known_modules
+                )
+                if unknown:
+                    modules = [mod]
 
             for module in modules:
                 mods_3rd_party.add(modsplit(module), requirement)

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -656,20 +656,13 @@ class Flake8Checker(object):
         mods_3rd_party = ModuleSet()
         # Get 3rd party module names based on requirements.
         for requirement in self.get_mods_3rd_party_requirements():
-            mod = project2module(requirement.project_name)
-            modules = (
-                self.known_3rd_parties.get(mod, []) +
-                self.known_host_3rd_parties.get(mod, []) +
-                self.known_modules.get(mod, [])
-            )
-            if not modules:
-                unknown = (
-                    mod not in self.known_3rd_parties and
-                    mod not in self.known_host_3rd_parties and
-                    mod not in self.known_modules
-                )
-                if unknown:
-                    modules = [mod]
+            modules = [project2module(requirement.project_name)]
+            if modules[0] in self.known_modules:
+                modules = self.known_modules[modules[0]]
+            elif modules[0] in self.known_3rd_parties:
+                modules = self.known_3rd_parties[modules[0]]
+            elif modules[0] in self.known_host_3rd_parties:
+                modules = self.known_host_3rd_parties[modules[0]]
 
             for module in modules:
                 mods_3rd_party.add(modsplit(module), requirement)

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -663,7 +663,6 @@ class Flake8Checker(object):
                 modules = self.known_3rd_parties[modules[0]]
             elif modules[0] in self.known_host_3rd_parties:
                 modules = self.known_host_3rd_parties[modules[0]]
-
             for module in modules:
                 mods_3rd_party.add(modsplit(module), requirement)
         return mods_3rd_party


### PR DESCRIPTION
Allow user-specified provided modules to add to internally specified ones

I noticed it didn't help adding my own `attrs:[attr, attrs]` to `.flake8` override the builtin one. I feel like you should be allowed to do that.