### PR TITLE
Add PEP 621 as a source for modules.

### DIFF
--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -537,6 +537,22 @@ class Flake8Checker(object):
             return {}
 
     @classmethod
+    def get_pyproject_toml_pep621(cls):
+        """Try to get PEP 621 metadata."""
+        cfg_pep621 = cls.get_pyproject_toml()
+        return cfg_pep621.get('project', {})
+
+    def get_pyproject_toml_pep621_requirements(self):
+        """Try to get PEP 621 metadata requirements."""
+        pep621 = self.get_pyproject_toml_pep621()
+        requirements = []
+        requirements.extend(parse_requirements(
+            pep621.get("dependencies", ())))
+        for r in pep621.get("optional-dependencies", {}).values():
+            requirements.extend(parse_requirements(r))
+        return requirements
+
+    @classmethod
     def get_pyproject_toml_poetry(cls):
         """Try to get poetry configuration."""
         cfg_pep518 = cls.get_pyproject_toml()
@@ -627,6 +643,7 @@ class Flake8Checker(object):
         modules = [project2module(
             cls.get_setup_py().keywords.get('name') or
             cls.get_setup_cfg().get('metadata', 'name') or
+            cls.get_pyproject_toml_pep621().get('name') or
             cls.get_pyproject_toml_poetry().get('name') or
             "")]
         if modules[0] in cls.known_modules:
@@ -645,6 +662,8 @@ class Flake8Checker(object):
             self.get_setup_py_requirements() or
             # Check setup configuration file for requirements.
             self.get_setup_cfg_requirements() or
+            # Check PEP 621 metadata for requirements.
+            self.get_pyproject_toml_pep621_requirements() or
             # Check project configuration for requirements.
             self.get_pyproject_toml_poetry_requirements() or
             # Fall-back to requirements.txt in our root directory.

--- a/test/test_pep621.py
+++ b/test/test_pep621.py
@@ -1,0 +1,62 @@
+import unittest
+
+from flake8_requirements.checker import Flake8Checker
+from flake8_requirements.checker import ModuleSet
+from flake8_requirements.checker import memoize
+
+try:
+    from unittest import mock
+    builtins_open = 'builtins.open'
+except ImportError:
+    import mock
+    builtins_open = '__builtin__.open'
+
+
+class Pep621TestCase(unittest.TestCase):
+
+    def setUp(self):
+        memoize.mem = {}
+        self.content = """
+        [project]
+        name="test"
+        dependencies=["tools==1.0"]
+
+        [project.optional-dependencies]
+        dev = ["dev-tools==1.0"]
+        """
+
+    def test_get_pyproject_toml_pep621(self):
+        with mock.patch(builtins_open, mock.mock_open(read_data=self.content)):
+            pep621 = Flake8Checker.get_pyproject_toml_pep621()
+            expected = {
+                "name": "test",
+                "dependencies": ["tools==1.0"],
+                "optional-dependencies": {
+                    "dev": ["dev-tools==1.0"]
+                },
+            }
+            self.assertDictEqual(pep621, expected)
+
+    def test_1st_party(self):
+        with mock.patch(builtins_open, mock.mock_open()) as m:
+            m.side_effect = (
+                IOError("No such file or directory: 'setup.py'"),
+                IOError("No such file or directory: 'setup.cfg'"),
+                mock.mock_open(read_data=self.content).return_value,
+            )
+
+            checker = Flake8Checker(None, None)
+            mods = checker.get_mods_1st_party()
+            self.assertEqual(mods, ModuleSet({"test": {}}))
+
+    def test_3rd_party(self):
+        with mock.patch(builtins_open, mock.mock_open()) as m:
+            m.side_effect = (
+                IOError("No such file or directory: 'setup.py'"),
+                IOError("No such file or directory: 'setup.cfg'"),
+                mock.mock_open(read_data=self.content).return_value,
+            )
+
+            checker = Flake8Checker(None, None)
+            mods = checker.get_mods_3rd_party()
+            self.assertEqual(mods, ModuleSet({"tools": {}, "dev_tools": {}}))


### PR DESCRIPTION
This adds support for reading project name, dependencies, and extras using [PEP 621](https://peps.python.org/pep-0621/) metadata in pyproject.toml. Setuptools added support in v61.0.0, many other pypa build tools have supported it for a while (flit, hatch, pdm, enscons that I know of), and poetry will (eventually) support it in v2.

I based the additions and tests on the existing ones for poetry, since they're pretty similar. Hopefully I didn't miss anything, but I'm happy to make adjustments if needed/desired.