### PR TITLE
Add support for flake8-pyproject

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,17 @@ Real life example::
   max-line-length = 100
   known-modules = my-lib:[mylib.drm,mylib.encryption]
 
+If you use `flake8-pyproject <https://pypi.org/project/Flake8-pyproject/>`_, you can also configure
+the known modules using a nicer syntax::
+
+  $ cat pyproject.toml
+  ...
+  [tool.flake8]
+  max-line-length = 100
+
+  [tool.flake8.known-modules]
+  my-lib = ["mylib.drm", "mylib.encryption"]
+
 It is also possible to scan host's site-packages directory for installed packages. This feature is
 disabled by default, but user can enable it with the ``--scan-host-site-packages`` command line
 option. Please note, however, that the location of the site-packages directory will be determined

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -18,7 +18,7 @@ from .modules import STDLIB_PY2
 from .modules import STDLIB_PY3
 
 # NOTE: Changing this number will alter package version as well.
-__version__ = "1.6.2"
+__version__ = "1.7.0"
 __license__ = "MIT"
 
 LOG = getLogger('flake8.plugin.requirements')
@@ -376,6 +376,7 @@ class Flake8Checker(object):
     def parse_options(cls, options):
         """Parse plug-in specific options."""
         if isinstance(options.known_modules, dict):
+            # Support for nicer known-modules using flake8-pyproject.
             cls.known_modules = {
                 project2module(k): v for k, v in options.known_modules.items()
             }

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -375,13 +375,18 @@ class Flake8Checker(object):
     @classmethod
     def parse_options(cls, options):
         """Parse plug-in specific options."""
-        cls.known_modules = {
-            project2module(k): v.split(",")
-            for k, v in [
-                x.split(":[")
-                for x in re.split(r"],?", options.known_modules)[:-1]
-            ]
-        }
+        if isinstance(options.known_modules, dict):
+            cls.known_modules = {
+                project2module(k): v for k, v in options.known_modules.items()
+            }
+        else:
+            cls.known_modules = {
+                project2module(k): v.split(",")
+                for k, v in [
+                    x.split(":[")
+                    for x in re.split(r"],?", options.known_modules)[:-1]
+                ]
+            }
         cls.requirements_file = options.requirements_file
         cls.requirements_max_depth = options.requirements_max_depth
         if options.scan_host_site_packages:

--- a/test/test_checker.py
+++ b/test/test_checker.py
@@ -35,7 +35,7 @@ class Flake8Checker(checker.Flake8Checker):
 class Flake8Options:
     known_modules = ""
     requirements_file = None
-    requirements_max_depth = 0
+    requirements_max_depth = 1
     scan_host_site_packages = False
 
 

--- a/test/test_pep621.py
+++ b/test/test_pep621.py
@@ -12,6 +12,13 @@ except ImportError:
     builtins_open = '__builtin__.open'
 
 
+class Flake8Options:
+    known_modules = ""
+    requirements_file = None
+    requirements_max_depth = 1
+    scan_host_site_packages = False
+
+
 class Pep621TestCase(unittest.TestCase):
 
     content = """
@@ -25,6 +32,18 @@ class Pep621TestCase(unittest.TestCase):
 
     def setUp(self):
         memoize.mem = {}
+
+    def tearDown(self):
+        Flake8Checker.root_dir = ""
+
+    def test_pyproject_custom_mapping_parser(self):
+        class Options(Flake8Options):
+            known_modules = {"mylib": ["mylib.drm", "mylib.ex"]}
+        Flake8Checker.parse_options(Options)
+        self.assertEqual(
+            Flake8Checker.known_modules,
+            {"mylib": ["mylib.drm", "mylib.ex"]},
+        )
 
     def test_get_pyproject_toml_pep621(self):
         with mock.patch(builtins_open, mock.mock_open(read_data=self.content)):


### PR DESCRIPTION
This allows configuring flake8-requirements in a much nicer way if you're using [flake8-pyproject](https://pypi.org/project/Flake8-pyproject/).

Before:
```toml
[tool.flake8]
known-modules = "a:[b],c:[d,e]"
```

After:
```toml
[tool.flake8.known-modules]
a = ["b"]
c = ["d", "e"]
```