### PR TITLE
Add opencv-contrib-python to known modules

### DIFF
--- a/src/flake8_requirements/modules.py
+++ b/src/flake8_requirements/modules.py
@@ -608,6 +608,7 @@ KNOWN_3RD_PARTIES = {
     "mysql-python": ["MySQLdb"],
     "mysqlclient": ["_mysql", "MySQLdb"],
     "opencv-python": ["cv2"],
+    "opencv-contrib-python": ["cv2"],
     "opencv-python-headless": ["cv2"],
     "opensearch-py": ["opensearchpy"],
     "opentelemetry-api": ["opentelemetry"],


### PR DESCRIPTION
https://pypi.org/project/opencv-contrib-python/ is a pre-built CPU-only OpenCV packages for Python