### PR TITLE
Fix modules.py def of 'cattrs' known 3rd party module

### DIFF
--- a/src/flake8_requirements/modules.py
+++ b/src/flake8_requirements/modules.py
@@ -556,7 +556,7 @@ KNOWN_3RD_PARTIES = {
     "azure-storage-queue": ["azure.storage.queue"],
     "beautifulsoup4": ["bs4"],
     "bitvector": ["BitVector"],
-    "cattrs": ["cattr"],
+    "cattrs": ["cattr", "cattrs"],
     "cx-oracle": ["cx_Oracle"],
     "databricks-connect": ["pyspark"],
     "django-ajax-selects": ["ajax_select"],


### PR DESCRIPTION
This was missing one of the namespaces included in that library.

Got to deep dive into this project.  Neat setup.  This was a confusing headscratcher though.  I'll be adding a TON to this known 3rd parties soon.