### PR TITLE
Switch from 'toml' package to tomli/tomllib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "flake8 >= 2.0.0",
         "setuptools >= 10.0.0",
-        "toml >= 0.7.0",
+        "tomli>=1.2.1; python_version < '3.11'",
     ],
     setup_requires=["pytest-runner"],
     tests_require=["mock", "pytest"],

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -9,9 +9,13 @@ from functools import wraps
 from logging import getLogger
 
 import flake8
-import toml
 from pkg_resources import parse_requirements
 from pkg_resources import yield_lines
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from .modules import KNOWN_3RD_PARTIES
 from .modules import STDLIB_PY2
@@ -545,10 +549,11 @@ class Flake8Checker(object):
     @memoize
     def get_pyproject_toml(cls):
         """Try to load PEP 518 configuration file."""
+        pyproject_config_path = os.path.join(cls.root_dir, "pyproject.toml")
         try:
-            with open(os.path.join(cls.root_dir, "pyproject.toml")) as f:
-                return toml.loads(f.read())
-        except (IOError, toml.TomlDecodeError) as e:
+            with open(pyproject_config_path, mode="rb") as f:
+                return tomllib.load(f)
+        except (IOError, tomllib.TOMLDecodeError) as e:
             LOG.debug("Couldn't load project setup: %s", e)
             return {}
 

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -22,7 +22,7 @@ from .modules import STDLIB_PY2
 from .modules import STDLIB_PY3
 
 # NOTE: Changing this number will alter package version as well.
-__version__ = "1.7.5"
+__version__ = "1.7.6"
 __license__ = "MIT"
 
 LOG = getLogger('flake8.plugin.requirements')

--- a/test/test_pep621.py
+++ b/test/test_pep621.py
@@ -21,7 +21,7 @@ class Flake8Options:
 
 class Pep621TestCase(unittest.TestCase):
 
-    content = """
+    content = b"""
     [project]
     name="test"
     dependencies=["tools==1.0"]
@@ -58,7 +58,7 @@ class Pep621TestCase(unittest.TestCase):
             self.assertDictEqual(pep621, expected)
 
     def test_get_pyproject_toml_invalid(self):
-        content = self.content + "invalid"
+        content = self.content + b"invalid"
         with mock.patch(builtins_open, mock.mock_open(read_data=content)):
             self.assertDictEqual(Flake8Checker.get_pyproject_toml_pep621(), {})
 

--- a/test/test_poetry.py
+++ b/test/test_poetry.py
@@ -18,13 +18,13 @@ class PoetryTestCase(unittest.TestCase):
         memoize.mem = {}
 
     def test_get_pyproject_toml_poetry(self):
-        content = "[tool.poetry]\nname='x'\n[tool.poetry.tag]\nx=0\n"
+        content = b"[tool.poetry]\nname='x'\n[tool.poetry.tag]\nx=0\n"
         with mock.patch(builtins_open, mock.mock_open(read_data=content)):
             poetry = Flake8Checker.get_pyproject_toml_poetry()
             self.assertDictEqual(poetry, {'name': "x", 'tag': {'x': 0}})
 
     def test_1st_party(self):
-        content = "[tool.poetry]\nname='book'\n"
+        content = b"[tool.poetry]\nname='book'\n"
 
         with mock.patch(builtins_open, mock.mock_open()) as m:
             m.side_effect = (
@@ -38,8 +38,8 @@ class PoetryTestCase(unittest.TestCase):
             self.assertEqual(mods, ModuleSet({"book": {}}))
 
     def test_3rd_party(self):
-        content = "[tool.poetry.dependencies]\ntools='1.0'\n"
-        content += "[tool.poetry.dev-dependencies]\ndev-tools='1.0'\n"
+        content = b"[tool.poetry.dependencies]\ntools='1.0'\n"
+        content += b"[tool.poetry.dev-dependencies]\ndev-tools='1.0'\n"
 
         with mock.patch(builtins_open, mock.mock_open()) as m:
             m.side_effect = (
@@ -53,8 +53,8 @@ class PoetryTestCase(unittest.TestCase):
             self.assertEqual(mods, ModuleSet({"tools": {}, "dev_tools": {}}))
 
     def test_3rd_party_groups(self):
-        content = "[tool.poetry.dependencies]\ntools='1.0'\n"
-        content += "[tool.poetry.group.dev.dependencies]\ndev-tools='1.0'\n"
+        content = b"[tool.poetry.dependencies]\ntools='1.0'\n"
+        content += b"[tool.poetry.group.dev.dependencies]\ndev-tools='1.0'\n"
 
         with mock.patch(builtins_open, mock.mock_open()) as m:
             m.side_effect = (


### PR DESCRIPTION
Python 3.11 comes with built-in support for TOML. It's an almost direct import of the tomli package. As the 'toml' library is unmaintained, and tomli has the same interface as what's in the standard library, this switches the TOML support to a supported library with a minimum of fuss.

Tomllib requires files to be opened in 'rb' mode, so the relevant tests had to be updated accordingly.

Fixes #70 