### PR TITLE
Add encodings to modules.STDLIB_PY3

### DIFF
--- a/src/flake8_requirements/modules.py
+++ b/src/flake8_requirements/modules.py
@@ -53,6 +53,7 @@ STDLIB_PY3 = (
     "doctest",
     "dummy_threading",
     "email",
+    "encodings",
     "ensurepip",
     "enum",
     "errno",


### PR DESCRIPTION
For reference: https://github.com/python/cpython/tree/3.12/Lib/encodings

The encodings package is around long time ago, even it is not very well documented. 
It is partially documented under https://docs.python.org/3/library/codecs.html