### PR TITLE
Created `pyproject` extra for `Flake8-pyproject`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,9 @@ Real life example::
   max-line-length = 100
   known-modules = my-lib:[mylib.drm,mylib.encryption]
 
-If you use `flake8-pyproject <https://pypi.org/project/Flake8-pyproject/>`_, you can also configure
-the known modules using a nicer syntax::
+If you use `Flake8-pyproject <https://pypi.org/project/Flake8-pyproject/>`_
+(can include for installation using ``flake8-requirements[toml]``),
+you can also configure the known modules using a nicer syntax in ``pyproject.toml``::
 
   $ cat pyproject.toml
   ...

--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,7 @@ Real life example::
   known-modules = my-lib:[mylib.drm,mylib.encryption]
 
 If you use `Flake8-pyproject <https://pypi.org/project/Flake8-pyproject/>`_
-(can include for installation using ``flake8-requirements[toml]``),
+(can include for installation using ``flake8-requirements[pyproject]``),
 you can also configure the known modules using a nicer syntax in ``pyproject.toml``::
 
   $ cat pyproject.toml

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "setuptools >= 10.0.0",
         "tomli>=1.2.1; python_version < '3.11'",
     ],
-    extras_require={"toml": ["Flake8-pyproject"]},
+    extras_require={"pyproject": ["Flake8-pyproject"]},
     setup_requires=["pytest-runner"],
     tests_require=["mock", "pytest"],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         "setuptools >= 10.0.0",
         "tomli>=1.2.1; python_version < '3.11'",
     ],
+    extras_require={"toml": ["Flake8-pyproject"]},
     setup_requires=["pytest-runner"],
     tests_require=["mock", "pytest"],
     entry_points={

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -20,7 +20,7 @@ from .modules import KNOWN_3RD_PARTIES
 from .modules import STDLIB_PY3
 
 # NOTE: Changing this number will alter package version as well.
-__version__ = "2.0.2"
+__version__ = "2.1.0"
 __license__ = "MIT"
 
 LOG = getLogger('flake8.plugin.requirements')


### PR DESCRIPTION
`flake8-requirements` is one of the last reasons I still use `flake8` since it was mostly ported to `ruff`.

I am adding the `pyproject` extra so my requirements file can go from:

```txt
flake8-requirements
Flake8-pyproject
```

To:

```txt
flake8-requirements[pyproject]
```