### PR TITLE
Install and use toml conditionally on Python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         "flake8 >= 2.0.0",
         "setuptools >= 10.0.0",
-        "toml >= 0.7.0; python_version < '3.0'",
+        "toml >= 0.7.1; python_version < '3.0'",
         "tomli >= 1.2.1; python_version >= '3.0' and python_version < '3.11'",
     ],
     setup_requires=["pytest-runner"],

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     install_requires=[
         "flake8 >= 2.0.0",
         "setuptools >= 10.0.0",
-        "tomli>=1.2.1; python_version < '3.11'",
+        "toml >= 0.7.0; python_version < '3.0'",
+        "tomli >= 1.2.1; python_version >= '3.0' and python_version < '3.11'",
     ],
     setup_requires=["pytest-runner"],
     tests_require=["mock", "pytest"],

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -12,17 +12,20 @@ import flake8
 from pkg_resources import parse_requirements
 from pkg_resources import yield_lines
 
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
+try:
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib
+except ImportError:
+    import toml
 
 from .modules import KNOWN_3RD_PARTIES
 from .modules import STDLIB_PY2
 from .modules import STDLIB_PY3
 
 # NOTE: Changing this number will alter package version as well.
-__version__ = "1.7.8"
+__version__ = "1.7.9"
 __license__ = "MIT"
 
 LOG = getLogger('flake8.plugin.requirements')
@@ -560,6 +563,13 @@ class Flake8Checker(object):
         except (IOError, tomllib.TOMLDecodeError) as e:
             LOG.debug("Couldn't load project setup: %s", e)
             return {}
+        except Exception:
+            try:
+                with open(pyproject_config_path, mode="rb") as f:
+                    return toml.loads(f.read())
+            except (IOError, toml.TomlDecodeError) as e:
+                LOG.debug("Couldn't load project setup: %s", e)
+                return {}
 
     @classmethod
     def get_pyproject_toml_pep621(cls):

--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -18,7 +18,7 @@ try:
     else:
         import tomli as tomllib
 except ImportError:
-    import toml
+    import toml as tomllib
 
 from .modules import KNOWN_3RD_PARTIES
 from .modules import STDLIB_PY2
@@ -560,16 +560,9 @@ class Flake8Checker(object):
         try:
             with open(pyproject_config_path, mode="rb") as f:
                 return tomllib.load(f)
-        except (IOError, tomllib.TOMLDecodeError) as e:
+        except Exception as e:
             LOG.debug("Couldn't load project setup: %s", e)
             return {}
-        except Exception:
-            try:
-                with open(pyproject_config_path, mode="rb") as f:
-                    return toml.loads(f.read())
-            except (IOError, toml.TomlDecodeError) as e:
-                LOG.debug("Couldn't load project setup: %s", e)
-                return {}
 
     @classmethod
     def get_pyproject_toml_pep621(cls):


### PR DESCRIPTION
tomli is not available for Python2, so to keep the Python2 compatibility, we need to install and use toml instead.

Use conditional import on ImportError to avoid introducing tox as new dependency.

Unfortunately toml's API is slightly different than tomli's and tomllib's, so we need additional implementation of the toml loading in case tomllib didn't work.

This PR is based on v1.7.8, as this is the latest Python2 compatible version, which unfortunately fails, because of the removal of toml. It is intended to introduce new v1.7.9 compatible with Python2 and is targeting to fix issue #75.