### PR TITLE
Add support for dynamic dependencies

### DIFF
--- a/src/flake8_requirements/checker.py
+++ b/src/flake8_requirements/checker.py
@@ -20,7 +20,7 @@ from .modules import KNOWN_3RD_PARTIES
 from .modules import STDLIB_PY3
 
 # NOTE: Changing this number will alter package version as well.
-__version__ = "2.1.1"
+__version__ = "2.2.0"
 __license__ = "MIT"
 
 LOG = getLogger('flake8.plugin.requirements')


### PR DESCRIPTION
The dynamic dependencies are part of pep621.
For now only the setuptools supports dynamic dependencies. Because of that the implementation is somehow dependent on setuptools. When other tool adds support for dynamic dependencies only the part for gathering of the dependencies has to be changed.